### PR TITLE
fix: use addressable gem to replace deprecated URI.encode

### DIFF
--- a/lib/mparticle/api_client.rb
+++ b/lib/mparticle/api_client.rb
@@ -3,7 +3,7 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
+require 'addressable/uri'
 
 module MParticle
   class ApiClient
@@ -273,7 +273,7 @@ module MParticle
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      Addressable::URI.encode(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/mparticle/configuration.rb
+++ b/lib/mparticle/configuration.rb
@@ -1,4 +1,4 @@
-require 'uri'
+require 'addressable/uri'
 
 module MParticle
   class Configuration
@@ -136,7 +136,7 @@ module MParticle
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      Addressable::URI.encode(url)
     end
 
     # Gets Basic Auth token string

--- a/mparticle.gemspec
+++ b/mparticle.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.0', '>= 2.3.0'
+  s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.0'
 
   s.files         = `find *`.split("\n").uniq.sort.select{|f| !f.empty? }
   s.executables   = []


### PR DESCRIPTION
## Summary
URI.encode is deprecated and now removed in the latest Ruby versions.
This PR adds the `addressable` gem as a dependency, and uses this gem to encode the URI.

This change just reflects the changes that would be made as if this SDK was regenerated using a more recent swagger-codegen.
You can see the changes made to swagger-codegen here: https://github.com/swagger-api/swagger-codegen/pull/10445